### PR TITLE
v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ DNAnexus workflow definition file of dias_single for germline analysis.
 -------
 
 ## Current Version: 2.1.0
+Input files were removed from the workflow description and need to be provided.
+
+This is to allow for flexibility and control of the input files via a config file.
 
 ## What apps are used in this workflow?
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # dias_single (DNAnexus Platform Workflow)
-DNAnexus workflow definition file of dias_single for germline analysis.
+DNAnexus workflow definition file of dias_single for germline analysis to be run once per sample on a sequencing run.
 
 -------
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ DNAnexus workflow definition file of dias_single for germline analysis.
 
 ## Current Version: 2.1.0
 
-## Release Notes:
-* Updated README to current version
-
 ## What apps are used in this workflow?
 
 |  App 	| Version  	|

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This is to allow for flexibility and control of the input files via a config fil
 |sention-dnaseq     |4.2.1|
 |verifybamid        |2.2.1|
 |vcf_qc 	        |1.0.1|
-|mosdepth           |1.0.1|
 |samtools_flagstat  |1.1.0|
 |picardqc           |1.0.0|
+|mosdepth           |1.0.1|
 |somalier_extract   |1.1.0|
 
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ DNAnexus workflow definition file of dias_single for germline analysis.
 |---	|---	|
 |multi_fastqc       |1.1.0|
 |sention-dnaseq     |4.2.1|
-|verifybamid        |2.2.0|
+|verifybamid        |2.2.1|
 |vcf_qc 	        |1.0.1|
 |mosdepth           |1.0.1|
 |samtools_flagstat  |1.1.0|

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ DNAnexus workflow definition file of dias_single for germline analysis.
 
 -------
 
-## Current Version: 2.0.1
+## Current Version: 2.1.0
 
 ## Release Notes:
 * Updated README to current version
@@ -13,13 +13,13 @@ DNAnexus workflow definition file of dias_single for germline analysis.
 |  App 	| Version  	|
 |---	|---	|
 |multi_fastqc       |1.1.0|
-|sention-dnaseq     |4.0.1|
-|verifybamid        |2.1.0|
-|vcf_qc 	        |1.0.1|  
+|sention-dnaseq     |4.2.1|
+|verifybamid        |2.2.0|
+|vcf_qc 	        |1.0.1|
 |mosdepth           |1.0.1|
-|samtools_flagstat  |1.0.0|
+|samtools_flagstat  |1.1.0|
 |picardqc           |1.0.0|
-|somalier_extract   |1.0.2|
+|somalier_extract   |1.1.0|
 
 
 #### This workflow was made by EMEE GLH

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -31,7 +31,7 @@
       }
     },
     {
-      "id": "stage-vcfqc",
+      "id": "stage-vcfQC",
       "executable": "applet-FpG4zY8433GbJ9Xj5vBvzBFp",
       "input": {
         "vcf_file": {

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -5,23 +5,28 @@
   "summary": "Germline single sample workflow",
   "stages": [
     {
-      "id": "fastqc",
+      "id": "stage-Fy6fpV840vZZ0v6J8qBQYqZF",
+      "name": "QC-fastqc",
       "executable": "applet-FvyXygj433GbKPPY0QY8ZKQG"
     },
     {
-      "id": "sentieon-dnaseq",
+      "id": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+      "name": "sentieon-dnaseq",
       "executable": "app-sentieon-dnaseq/4.2.1",
       "input": {
         "output_metrics": true,
         "ignore_decoy": true,
+        "genome_fastagz": {
+          "$dnanexus_link": {
+            "project": "project-F3zxk7Q4F30Xp8fG69K1Vppj",
+            "id": "file-F403K904F30y2vpVFqxB9kz7"
+          }
+        },
         "genomebwaindex_targz": {
           "$dnanexus_link": {
             "project": "project-F3zxk7Q4F30Xp8fG69K1Vppj",
             "id": "file-F404y604F30fbxQG68KF3GZb"
           }
-        },
-        "genome_fastagz": {
-          "$dnanexus_link": "file-F403K904F30y2vpVFqxB9kz7"
         },
         "gatk_resource_bundle": {
           "$dnanexus_link": {
@@ -32,91 +37,102 @@
       }
     },
     {
-      "id": "verifybamid",
+      "id": "stage-Fy6fq5840vZfYPKj25827FbZ",
+      "name": "QC-verifybamid",
       "executable": "app-eggd_verifybamid/2.2.0",
       "input": {
         "vcf_file": {
-          "$dnanexus_link": "file-G08V2gj41zgGYp1K79YZXqx8"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G08V2gj41zgGYp1K79YZXqx8"
+          }
         },
         "input_bam": {
           "$dnanexus_link": {
-            "stage": "sentieon-dnaseq",
+            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
             "outputField": "mappings_bam"
           }
         },
         "input_bam_index": {
           "$dnanexus_link": {
-            "stage": "sentieon-dnaseq",
+            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
             "outputField": "mappings_bam_bai"
           }
         }
       }
     },
     {
-      "id": "QC-vcf-qc",
+      "id": "stage-Fy6fqy040vZV3Gj24vppvJgZ",
+      "name": "QC-vcf-qc",
       "executable": "applet-FpG4zY8433GbJ9Xj5vBvzBFp",
       "input": {
         "vcf_file": {
           "$dnanexus_link": {
-            "stage": "sentieon-dnaseq",
+            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
             "outputField": "variants_vcf"
           }
         },
         "bed_file": {
-          "$dnanexus_link": "file-Fpz2X0Q433GVK5xxPvzqvVPB"
+          "$dnanexus_link": {
+            "project": "project-Fv2gqv04kxV0QZgY3gZ1VG0P",
+            "id": "file-Fpz2X0Q433GVK5xxPvzqvVPB"
+          }
         }
       }
     },
     {
-      "id": "QC-samtools_flagstat",
+      "id": "stage-Fy6fvx040vZfybXg85Zgkjv0",
+      "name": "QC-samtools_flagstat",
       "executable": "app-eggd_samtools_flagstat/1.1.0",
       "input": {
-        "input_bam": {
-          "$dnanexus_link": {
-            "stage": "sentieon-dnaseq",
-            "outputField": "mappings_bam"
-          }
-        },
         "input_bam_index": {
           "$dnanexus_link": {
-            "stage": "sentieon-dnaseq",
+            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
             "outputField": "mappings_bam_bai"
+          }
+        },
+        "input_bam": {
+          "$dnanexus_link": {
+            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "outputField": "mappings_bam"
           }
         }
       }
     },
     {
-      "id": "QC-picard-qc",
+      "id": "stage-Fy6fx2Q40vZbFVxZ283xXGVY",
+      "name": "QC-picardQC",
       "executable": "applet-Fp69k884qBzVfbvP812F92gG",
       "input": {
-        "run_CollectMultipleMetrics": false,
         "sorted_bam": {
           "$dnanexus_link": {
-            "stage": "sentieon-dnaseq",
+            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
             "outputField": "mappings_bam"
           }
         },
-        "bedfile": {
-          "$dnanexus_link": "file-G2J5ZV0433GQJz7860vb4PB1"
-        },
+        "run_CollectMultipleMetrics": false,
         "fasta_index": {
-          "$dnanexus_link": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
+          "$dnanexus_link": {
+            "project": "project-F3zqGV04fXX5j7566869fjFq",
+            "id": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
+          }
         }
       }
     },
     {
-      "id": "coverage-metrics",
+      "id": "stage-Fy6fvYQ40vZV1y8p9GYKPYyQ",
+      "name": "coverage-mosdepth",
       "executable": "applet-Fxq07gQ433Gyz14j5ZZ1fzk1",
       "input": {
         "bam": {
           "$dnanexus_link": {
-            "stage": "sentieon-dnaseq",
+            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
             "outputField": "mappings_bam"
           }
         },
         "index": {
           "$dnanexus_link": {
-            "stage": "sentieon-dnaseq",
+            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
             "outputField": "mappings_bam_bai"
           }
         }
@@ -124,22 +140,38 @@
     },
     {
       "id": "stage-G5gzP78433GVJ1z1PBKBqxzy",
+      "name": "somalier-extract",
       "executable": "app-eggd_somalier_extract/1.1.0",
       "input": {
-        "sample_vcf": {
+        "somalier_docker": {
           "$dnanexus_link": {
-            "stage": "sentieon-dnaseq",
-            "outputField": "variants_vcf"
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-GPQX4G04x14XV5PFfqGkGJk1"
+          }
+        },
+        "reference_genome": {
+          "$dnanexus_link": {
+            "project": "project-Fv2gqv04kxV0QZgY3gZ1VG0P",
+            "id": "file-F403K904F30y2vpVFqxB9kz7"
+          }
+        },
+        "reference_genome_index": {
+          "$dnanexus_link": {
+            "project": "project-Fv2gqv04kxV0QZgY3gZ1VG0P",
+            "id": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
           }
         },
         "snp_site_vcf": {
-          "$dnanexus_link": "file-G18PB8Q4vQpfvPv83qKpj2QG"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G18PB8Q4vQpfvPv83qKpj2QG"
+          }
         },
-        "reference_genome": {
-          "$dnanexus_link": "file-F403K904F30y2vpVFqxB9kz7"
-        },
-        "reference_genome_index": {
-          "$dnanexus_link": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
+        "sample_vcf": {
+          "$dnanexus_link": {
+            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "outputField": "variants_vcf"
+          }
         }
       }
     }

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -14,26 +14,6 @@
       "name": "sentieon_dnaseq",
       "executable": "app-sentieon-dnaseq/4.2.1",
       "input": {
-        "output_metrics": true,
-        "ignore_decoy": true,
-        "genome_fastagz": {
-          "$dnanexus_link": {
-            "project": "project-F3zxk7Q4F30Xp8fG69K1Vppj",
-            "id": "file-F403K904F30y2vpVFqxB9kz7"
-          }
-        },
-        "genomebwaindex_targz": {
-          "$dnanexus_link": {
-            "project": "project-F3zxk7Q4F30Xp8fG69K1Vppj",
-            "id": "file-F404y604F30fbxQG68KF3GZb"
-          }
-        },
-        "gatk_resource_bundle": {
-          "$dnanexus_link": {
-            "project": "project-F3zqGV04fXX5j7566869fjFq",
-            "id": "file-F3zx7gj4fXX8QG3Q42BzpyZJ"
-          }
-        }
       }
     },
     {
@@ -41,12 +21,6 @@
       "name": "verifybamid",
       "executable": "app-eggd_verifybamid/2.2.1",
       "input": {
-        "vcf_file": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-G08V2gj41zgGYp1K79YZXqx8"
-          }
-        },
         "input_bam": {
           "$dnanexus_link": {
             "stage": "stage-sentieon_dnaseq",
@@ -70,12 +44,6 @@
           "$dnanexus_link": {
             "stage": "stage-sentieon_dnaseq",
             "outputField": "variants_vcf"
-          }
-        },
-        "bed_file": {
-          "$dnanexus_link": {
-            "project": "project-Fv2gqv04kxV0QZgY3gZ1VG0P",
-            "id": "file-Fpz2X0Q433GVK5xxPvzqvVPB"
           }
         }
       }
@@ -109,13 +77,6 @@
             "stage": "stage-sentieon_dnaseq",
             "outputField": "mappings_bam"
           }
-        },
-        "run_CollectMultipleMetrics": false,
-        "fasta_index": {
-          "$dnanexus_link": {
-            "project": "project-F3zqGV04fXX5j7566869fjFq",
-            "id": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
-          }
         }
       }
     },
@@ -143,30 +104,6 @@
       "name": "somalier_extract",
       "executable": "app-eggd_somalier_extract/1.1.0",
       "input": {
-        "somalier_docker": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-GPQX4G04x14XV5PFfqGkGJk1"
-          }
-        },
-        "reference_genome": {
-          "$dnanexus_link": {
-            "project": "project-Fv2gqv04kxV0QZgY3gZ1VG0P",
-            "id": "file-F403K904F30y2vpVFqxB9kz7"
-          }
-        },
-        "reference_genome_index": {
-          "$dnanexus_link": {
-            "project": "project-Fv2gqv04kxV0QZgY3gZ1VG0P",
-            "id": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
-          }
-        },
-        "snp_site_vcf": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-G18PB8Q4vQpfvPv83qKpj2QG"
-          }
-        },
         "sample_vcf": {
           "$dnanexus_link": {
             "stage": "stage-sentieon_dnaseq",

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -13,8 +13,6 @@
       "id": "stage-sentieon_dnaseq",
       "name": "sentieon_dnaseq",
       "executable": "app-sentieon-dnaseq/4.2.1",
-      "input": {
-      }
     },
     {
       "id": "stage-verifybamid",

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,117 +1,122 @@
 {
-  "name": "dias_single_v2.0.1",
-  "title": "dias_single_v2.0.1",
+  "name": "dias_single_v2.1.0",
+  "title": "dias_single_v2.1.0",
+  "version": "2.1.0",
+  "summary": "Germline single sample workflow",
   "stages": [
     {
-      "id": "stage-Fy6fpV840vZZ0v6J8qBQYqZF",
+      "id": "fastqc",
       "executable": "applet-FvyXygj433GbKPPY0QY8ZKQG"
     },
     {
-      "id": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
-      "executable": "app-sentieon-dnaseq/4.0.1",
+      "id": "sentieon-dnaseq",
+      "executable": "app-sentieon-dnaseq/4.2.1",
       "input": {
         "output_metrics": true,
-        "gatk_resource_bundle": {
+        "ignore_decoy": true,
+        "genomebwaindex_targz": {
           "$dnanexus_link": {
-            "project": "project-F3zqGV04fXX5j7566869fjFq",
-            "id": "file-F3zvKp84fXX8qJx43zZXP395"
+            "project": "project-F3zxk7Q4F30Xp8fG69K1Vppj",
+            "id": "file-F404y604F30fbxQG68KF3GZb"
           }
         },
         "genome_fastagz": {
-          "$dnanexus_link": "file-G9z3yG84kj4JPPYx6xQ85kyf"
+          "$dnanexus_link": "file-F403K904F30y2vpVFqxB9kz7"
         },
-        "genomebwaindex_targz": {
-          "$dnanexus_link": "file-GBQv7Z04G5G95z9V97kX03Jj"
-        },
-        "ignore_decoy": true
+        "gatk_resource_bundle": {
+          "$dnanexus_link": {
+            "project": "project-F3zqGV04fXX5j7566869fjFq",
+            "id": "file-F3zx7gj4fXX8QG3Q42BzpyZJ"
+          }
+        }
       }
     },
     {
-      "id": "stage-Fy6fq5840vZfYPKj25827FbZ",
-      "executable": "applet-G0Kb58Q433GVv31xKZXF169k",
+      "id": "verifybamid",
+      "executable": "app-eggd_verifybamid/2.2.0",
       "input": {
         "vcf_file": {
-          "$dnanexus_link": "file-G7YKFZj4kj47GxgQ2bKGYV1g"
+          "$dnanexus_link": "file-G08V2gj41zgGYp1K79YZXqx8"
         },
         "input_bam": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "sentieon-dnaseq",
             "outputField": "mappings_bam"
           }
         },
         "input_bam_index": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "sentieon-dnaseq",
             "outputField": "mappings_bam_bai"
           }
         }
       }
     },
     {
-      "id": "stage-Fy6fqy040vZV3Gj24vppvJgZ",
+      "id": "QC-vcf-qc",
       "executable": "applet-FpG4zY8433GbJ9Xj5vBvzBFp",
       "input": {
         "vcf_file": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "sentieon-dnaseq",
             "outputField": "variants_vcf"
           }
         },
         "bed_file": {
-          "$dnanexus_link": "file-GBZq5404kj46gxyg2KKFK3zv"
+          "$dnanexus_link": "file-Fpz2X0Q433GVK5xxPvzqvVPB"
         }
       }
     },
     {
-      "id": "stage-Fy6fvx040vZfybXg85Zgkjv0",
-      "executable": "applet-Fk5z0V84yBGZ5P7q3gFgFB64",
+      "id": "QC-samtools_flagstat",
+      "executable": "app-eggd_samtools_flagstat/1.1.0",
       "input": {
         "input_bam": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "sentieon-dnaseq",
             "outputField": "mappings_bam"
           }
         },
         "input_bam_index": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "sentieon-dnaseq",
             "outputField": "mappings_bam_bai"
           }
         }
       }
     },
     {
-      "id": "stage-Fy6fx2Q40vZbFVxZ283xXGVY",
+      "id": "QC-picard-qc",
       "executable": "applet-Fp69k884qBzVfbvP812F92gG",
       "input": {
         "run_CollectMultipleMetrics": false,
         "sorted_bam": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "sentieon-dnaseq",
             "outputField": "mappings_bam"
           }
         },
         "bedfile": {
-          "$dnanexus_link": "file-G7FK1xQ4kj4317YGFpqYPb75"
+          "$dnanexus_link": "file-G2J5ZV0433GQJz7860vb4PB1"
         },
         "fasta_index": {
-          "$dnanexus_link": "file-GBV0Qyj4kj40X34V5ypZG5X8"
+          "$dnanexus_link": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
         }
       }
     },
     {
-      "id": "stage-Fy6fvYQ40vZV1y8p9GYKPYyQ",
+      "id": "coverage-metrics",
       "executable": "applet-Fxq07gQ433Gyz14j5ZZ1fzk1",
       "input": {
         "bam": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "sentieon-dnaseq",
             "outputField": "mappings_bam"
           }
         },
         "index": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "sentieon-dnaseq",
             "outputField": "mappings_bam_bai"
           }
         }
@@ -119,22 +124,22 @@
     },
     {
       "id": "stage-G5gzP78433GVJ1z1PBKBqxzy",
-      "executable": "applet-G5YG118433Gk5xPbGx172fq8",
+      "executable": "app-eggd_somalier_extract/1.1.0",
       "input": {
         "sample_vcf": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "sentieon-dnaseq",
             "outputField": "variants_vcf"
           }
         },
         "snp_site_vcf": {
-          "$dnanexus_link": "file-G7FJjz04kj424vq826gKbZx7"
+          "$dnanexus_link": "file-G18PB8Q4vQpfvPv83qKpj2QG"
         },
         "reference_genome": {
-          "$dnanexus_link": "file-G9z3yG84kj4JPPYx6xQ85kyf"
+          "$dnanexus_link": "file-F403K904F30y2vpVFqxB9kz7"
         },
         "reference_genome_index": {
-          "$dnanexus_link": "file-GBV0Qyj4kj40X34V5ypZG5X8"
+          "$dnanexus_link": "file-F3zxG0Q4fXX9YFjP1v5jK9jf"
         }
       }
     }

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -46,16 +46,16 @@
       "id": "stage-samtools_flagstat",
       "executable": "app-eggd_samtools_flagstat/1.1.0",
       "input": {
-        "input_bam_index": {
-          "$dnanexus_link": {
-            "stage": "stage-sentieon_dnaseq",
-            "outputField": "mappings_bam_bai"
-          }
-        },
         "input_bam": {
           "$dnanexus_link": {
             "stage": "stage-sentieon_dnaseq",
             "outputField": "mappings_bam"
+          }
+        },
+        "input_bam_index": {
+          "$dnanexus_link": {
+            "stage": "stage-sentieon_dnaseq",
+            "outputField": "mappings_bam_bai"
           }
         }
       }

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -6,17 +6,14 @@
   "stages": [
     {
       "id": "stage-fastQC",
-      "name": "fastqc",
       "executable": "applet-FvyXygj433GbKPPY0QY8ZKQG"
     },
     {
       "id": "stage-sentieon_dnaseq",
-      "name": "sentieon_dnaseq",
       "executable": "app-sentieon-dnaseq/4.2.1"
     },
     {
       "id": "stage-verifybamid",
-      "name": "verifybamid",
       "executable": "app-eggd_verifybamid/2.2.1",
       "input": {
         "input_bam": {
@@ -35,7 +32,6 @@
     },
     {
       "id": "stage-vcfqc",
-      "name": "vcfqc",
       "executable": "applet-FpG4zY8433GbJ9Xj5vBvzBFp",
       "input": {
         "vcf_file": {
@@ -48,7 +44,6 @@
     },
     {
       "id": "stage-samtools_flagstat",
-      "name": "samtools_flagstat",
       "executable": "app-eggd_samtools_flagstat/1.1.0",
       "input": {
         "input_bam_index": {
@@ -67,7 +62,6 @@
     },
     {
       "id": "stage-picardQC",
-      "name": "picardQC",
       "executable": "applet-Fp69k884qBzVfbvP812F92gG",
       "input": {
         "sorted_bam": {
@@ -80,7 +74,6 @@
     },
     {
       "id": "stage-mosdepth",
-      "name": "mosdepth",
       "executable": "applet-Fxq07gQ433Gyz14j5ZZ1fzk1",
       "input": {
         "bam": {
@@ -99,7 +92,6 @@
     },
     {
       "id": "stage-somalier_extract",
-      "name": "somalier_extract",
       "executable": "app-eggd_somalier_extract/1.1.0",
       "input": {
         "sample_vcf": {

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -5,13 +5,13 @@
   "summary": "Germline single sample workflow",
   "stages": [
     {
-      "id": "stage-Fy6fpV840vZZ0v6J8qBQYqZF",
-      "name": "QC-fastqc",
+      "id": "stage-fastQC",
+      "name": "fastqc",
       "executable": "applet-FvyXygj433GbKPPY0QY8ZKQG"
     },
     {
-      "id": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
-      "name": "sentieon-dnaseq",
+      "id": "stage-sentieon_dnaseq",
+      "name": "sentieon_dnaseq",
       "executable": "app-sentieon-dnaseq/4.2.1",
       "input": {
         "output_metrics": true,
@@ -37,9 +37,9 @@
       }
     },
     {
-      "id": "stage-Fy6fq5840vZfYPKj25827FbZ",
-      "name": "QC-verifybamid",
-      "executable": "app-eggd_verifybamid/2.2.0",
+      "id": "stage-verifybamid",
+      "name": "verifybamid",
+      "executable": "app-eggd_verifybamid/2.2.1",
       "input": {
         "vcf_file": {
           "$dnanexus_link": {
@@ -49,26 +49,26 @@
         },
         "input_bam": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "stage-sentieon_dnaseq",
             "outputField": "mappings_bam"
           }
         },
         "input_bam_index": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "stage-sentieon_dnaseq",
             "outputField": "mappings_bam_bai"
           }
         }
       }
     },
     {
-      "id": "stage-Fy6fqy040vZV3Gj24vppvJgZ",
-      "name": "QC-vcf-qc",
+      "id": "stage-vcfqc",
+      "name": "vcfqc",
       "executable": "applet-FpG4zY8433GbJ9Xj5vBvzBFp",
       "input": {
         "vcf_file": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "stage-sentieon_dnaseq",
             "outputField": "variants_vcf"
           }
         },
@@ -81,32 +81,32 @@
       }
     },
     {
-      "id": "stage-Fy6fvx040vZfybXg85Zgkjv0",
-      "name": "QC-samtools_flagstat",
+      "id": "stage-samtools_flagstat",
+      "name": "samtools_flagstat",
       "executable": "app-eggd_samtools_flagstat/1.1.0",
       "input": {
         "input_bam_index": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "stage-sentieon_dnaseq",
             "outputField": "mappings_bam_bai"
           }
         },
         "input_bam": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "stage-sentieon_dnaseq",
             "outputField": "mappings_bam"
           }
         }
       }
     },
     {
-      "id": "stage-Fy6fx2Q40vZbFVxZ283xXGVY",
-      "name": "QC-picardQC",
+      "id": "stage-picardQC",
+      "name": "picardQC",
       "executable": "applet-Fp69k884qBzVfbvP812F92gG",
       "input": {
         "sorted_bam": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "stage-sentieon_dnaseq",
             "outputField": "mappings_bam"
           }
         },
@@ -120,27 +120,27 @@
       }
     },
     {
-      "id": "stage-Fy6fvYQ40vZV1y8p9GYKPYyQ",
-      "name": "coverage-mosdepth",
+      "id": "stage-mosdepth",
+      "name": "mosdepth",
       "executable": "applet-Fxq07gQ433Gyz14j5ZZ1fzk1",
       "input": {
         "bam": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "stage-sentieon_dnaseq",
             "outputField": "mappings_bam"
           }
         },
         "index": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "stage-sentieon_dnaseq",
             "outputField": "mappings_bam_bai"
           }
         }
       }
     },
     {
-      "id": "stage-G5gzP78433GVJ1z1PBKBqxzy",
-      "name": "somalier-extract",
+      "id": "stage-somalier_extract",
+      "name": "somalier_extract",
       "executable": "app-eggd_somalier_extract/1.1.0",
       "input": {
         "somalier_docker": {
@@ -169,7 +169,7 @@
         },
         "sample_vcf": {
           "$dnanexus_link": {
-            "stage": "stage-Fy6fpk040vZZPPbq96Jb2KfK",
+            "stage": "stage-sentieon_dnaseq",
             "outputField": "variants_vcf"
           }
         }

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -12,7 +12,7 @@
     {
       "id": "stage-sentieon_dnaseq",
       "name": "sentieon_dnaseq",
-      "executable": "app-sentieon-dnaseq/4.2.1",
+      "executable": "app-sentieon-dnaseq/4.2.1"
     },
     {
       "id": "stage-verifybamid",


### PR DESCRIPTION
## Summary of changes:
- update executables from applet to app where available (verifybamid, samtools_flagstat)
- update executable to latest version with relevant improvements: sentieon from v2 to v4, somalier_extract has changes relevant for the move to Epic-style sample naming
- remove input files from workflow definition into the corresponding eggd_conductor config file (for CEN and WES)

### Example job:
Set off with eggd_conductor config version v1.1.1 for CEN: https://platform.dnanexus.com/projects/GQKqF7j47f0G6XzqyJvJP3Y2/monitor/analysis/GQj911Q47f0B4zzbFyGP4BVQ


For further details on this update please see: [DI-217](https://cuhbioinformatics.atlassian.net/browse/DI-217)


[DI-217]: https://cuhbioinformatics.atlassian.net/browse/DI-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_single_workflow/15)
<!-- Reviewable:end -->
