### PR TITLE
updated app versions of mosdepth, picard_qc, and verifybamid to latest releases

### DIFF
--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -11,7 +11,8 @@
     "v2.8.0": "Update Sentieon to 202308.03 (5.1.0)",
     "v2.9.0": "Added new eggd_additional_regions_calling app",
     "v2.10.0": "Update eggd_additional_regions_calling to v1.1.0",
-    "v2.11.0": "Update vcf_qc to v2.1.0"
+    "v2.11.0": "Update vcf_qc to v2.1.0",
+    "v2.12.0": "Update eggd_picard_qc to v1.2.0; update eggd_mosdepth to v1.2.0; update eggd_verifybamid to v2.3.0"
   },
   "stages": [
     {
@@ -24,7 +25,7 @@
     },
     {
       "id": "stage-verifybamid",
-      "executable": "app-eggd_verifybamid/2.2.1",
+      "executable": "app-eggd_verifybamid/2.3.0",
       "input": {
         "input_bam": {
           "$dnanexus_link": {
@@ -72,7 +73,7 @@
     },
     {
       "id": "stage-picardQC",
-      "executable": "app-eggd_picard_QC/1.1.0",
+      "executable": "app-eggd_picard_QC/1.2.0",
       "input": {
         "sorted_bam": {
           "$dnanexus_link": {
@@ -84,7 +85,7 @@
     },
     {
       "id": "stage-mosdepth",
-      "executable": "app-eggd_mosdepth/1.1.0",
+      "executable": "app-eggd_mosdepth/1.2.0",
       "input": {
         "bam": {
           "$dnanexus_link": {


### PR DESCRIPTION
Apps updated to following versions:

- eggd_picard_qc: v1.2.0 
- eggd_mosdepth: v1.2.0 
- eggd_verifybamid: v2.3.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_single_workflow/29)
<!-- Reviewable:end -->
