### PR TITLE
V2.12.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ DNAnexus workflow definition file of dias_single for germline analysis to be run
 
 -------
 
-## Current Version: 2.11.0
+## Current Version: 2.12.0
 Input files were removed from the workflow description and need to be provided.
 
 This is to allow for flexibility and control of the input files via a config file.
@@ -14,11 +14,11 @@ This is to allow for flexibility and control of the input files via a config fil
 |---	|---	|
 |eggd_fastqc       |1.2.0|
 |sention-dnaseq     |5.1.0|
-|verifybamid        |2.2.1|
+|verifybamid        |2.3.0|
 |vcf_qc 	        |2.1.0|
 |samtools_flagstat  |1.1.0|
-|picardqc           |1.1.0|
-|mosdepth           |1.1.0|
+|picardqc           |1.2.0|
+|mosdepth           |1.2.0|
 |somalier_extract   |1.2.0|
 |sex_check          |1.1.0|
 |eggd_additional_regions_calling	|1.1.0|

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,7 +1,7 @@
 {
-  "name": "dias_single_v2.11.0",
-  "title": "dias_single_v2.11.0",
-  "version": "2.11.0",
+  "name": "dias_single_v2.12.0",
+  "title": "dias_single_v2.12.0",
+  "version": "2.12.0",
   "summary": "Germline single sample workflow",
   "whatsNew": {
     "v2.4.0": "Sentieon updated to v4.2.2",

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -27,13 +27,13 @@
       "id": "stage-verifybamid",
       "executable": "app-eggd_verifybamid/2.3.0",
       "input": {
-        "input_bam": {
+        "input_file": {
           "$dnanexus_link": {
             "stage": "stage-sentieon_dnaseq",
             "outputField": "mappings_bam"
           }
         },
-        "input_bam_index": {
+        "input_file_index": {
           "$dnanexus_link": {
             "stage": "stage-sentieon_dnaseq",
             "outputField": "mappings_bam_bai"
@@ -87,13 +87,13 @@
       "id": "stage-mosdepth",
       "executable": "app-eggd_mosdepth/1.2.0",
       "input": {
-        "bam": {
+        "alignment_file": {
           "$dnanexus_link": {
             "stage": "stage-sentieon_dnaseq",
             "outputField": "mappings_bam"
           }
         },
-        "index": {
+        "alignment_index": {
           "$dnanexus_link": {
             "stage": "stage-sentieon_dnaseq",
             "outputField": "mappings_bam_bai"

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -11,7 +11,8 @@
     "v2.8.0": "Update Sentieon to 202308.03 (5.1.0)",
     "v2.9.0": "Added new eggd_additional_regions_calling app",
     "v2.10.0": "Update eggd_additional_regions_calling to v1.1.0",
-    "v2.11.0": "Update vcf_qc to v2.1.0"
+    "v2.11.0": "Update vcf_qc to v2.1.0",
+    "v2.12.0": "Update eggd_picard_qc to v1.2.0; update eggd_mosdepth to v1.2.0; update eggd_verifybamid to v2.3.0"
   },
   "stages": [
     {
@@ -24,7 +25,7 @@
     },
     {
       "id": "stage-verifybamid",
-      "executable": "app-eggd_verifybamid/2.2.1",
+      "executable": "app-eggd_verifybamid/2.3.0",
       "input": {
         "input_bam": {
           "$dnanexus_link": {
@@ -72,7 +73,7 @@
     },
     {
       "id": "stage-picardQC",
-      "executable": "app-eggd_picard_QC/1.1.0",
+      "executable": "app-eggd_picard_QC/1.2.0",
       "input": {
         "sorted_bam": {
           "$dnanexus_link": {
@@ -84,7 +85,7 @@
     },
     {
       "id": "stage-mosdepth",
-      "executable": "app-eggd_mosdepth/1.1.0",
+      "executable": "app-eggd_mosdepth/1.2.0",
       "input": {
         "bam": {
           "$dnanexus_link": {


### PR DESCRIPTION
App versions updated (including changes to input argument names):

- eggd_mosdepth → v1.2.0
- eggd_picard_qc → v1.2.0
- eggd_verifybamid → v2.3.0
- eggd_vcf_qc → v2.1.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_dias_single_workflow/32)
<!-- Reviewable:end -->
